### PR TITLE
Bugfix/15 hash symbol in filename templates

### DIFF
--- a/artdaq-database/DataFormats/Fhicl/fhicl_reader.h
+++ b/artdaq-database/DataFormats/Fhicl/fhicl_reader.h
@@ -52,11 +52,12 @@ struct fhicl_comments_parser_grammar : qi::grammar<Iter, comments_t(), qi::blank
 
     whitespace_rule = *(ascii::char_ - (lit("#") | lit("//")));
 
-    whitespace_b4quotedstring_rule = *(ascii::char_ - (lit("\"") | lit("#") | lit("//")));
+    whitespace_b4quotedstring_rule = *(ascii::char_ - (lit("\"") | lit("\'") | lit("#") | lit("//")));
 
-    quoted_string_rule = '"' >> +(ascii::char_ - '"') >> '"';
+    double_quoted_string_rule = lit("\"") >> +(ascii::char_ - lit("\"")) >> lit("\"");
+    single_quoted_string_rule = lit("\'") >> +(ascii::char_ - lit("\'")) >> lit("\'");
 
-    padded_quoted_string_rule = whitespace_b4quotedstring_rule >> *(quoted_string_rule >> whitespace_b4quotedstring_rule);
+    padded_quoted_string_rule = whitespace_b4quotedstring_rule >> *((double_quoted_string_rule|single_quoted_string_rule) >> whitespace_b4quotedstring_rule);
 
     string_rule = +(ascii::char_ - (eol | eoi));
 
@@ -65,7 +66,7 @@ struct fhicl_comments_parser_grammar : qi::grammar<Iter, comments_t(), qi::blank
     comments_rule = (padded_quoted_string_rule >> whitespace_rule >> comment_rule) % eol;
   }
 
-  qi::rule<Iter> whitespace_rule, whitespace_b4quotedstring_rule, padded_quoted_string_rule, quoted_string_rule;
+  qi::rule<Iter> whitespace_rule, whitespace_b4quotedstring_rule, padded_quoted_string_rule, double_quoted_string_rule, single_quoted_string_rule;
   qi::rule<Iter, std::string()> string_rule;
   qi::rule<Iter, linenum_comment_t()> comment_rule;
   qi::rule<Iter, comments_t(), qi::blank_type> comments_rule;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 cet_enable_asserts()
 
+find_package(Boost COMPONENTS filesystem program_options system unit_test_framework REQUIRED)
+
 IF (FORMAT_WITH_CLANG)
   string(TOUPPER ${FORMAT_WITH_CLANG} FORMAT_WITH_CLANG_UC )
   if( ${FORMAT_WITH_CLANG_UC} MATCHES "TRUE" )

--- a/test/DataFormats/Fhicl/fcl2dbjson/test003/CMakeLists.txt
+++ b/test/DataFormats/Fhicl/fcl2dbjson/test003/CMakeLists.txt
@@ -99,3 +99,17 @@ cet_test(${TEST_NAME}_${TEST_NUMBER}_t HANDBUILT  TEST_EXEC ConvertFhicl_t
   DATAFILES 
     ${CMAKE_CURRENT_SOURCE_DIR}/test${TEST_NUMBER}.fcl 
   TEST_ARGS -s test${TEST_NUMBER}.fcl -c test${TEST_NUMBER}.fcl -t ${TEST_NAME})
+
+SET ( TEST_NUMBER "015" )
+
+cet_test(${TEST_NAME}_${TEST_NUMBER}_t HANDBUILT  TEST_EXEC ConvertFhicl_t 
+  DATAFILES 
+    ${CMAKE_CURRENT_SOURCE_DIR}/test${TEST_NUMBER}.fcl 
+  TEST_ARGS -s test${TEST_NUMBER}.fcl -c test${TEST_NUMBER}.fcl -t ${TEST_NAME})
+
+SET ( TEST_NUMBER "016" )
+
+cet_test(${TEST_NAME}_${TEST_NUMBER}_t HANDBUILT  TEST_EXEC ConvertFhicl_t 
+  DATAFILES 
+    ${CMAKE_CURRENT_SOURCE_DIR}/test${TEST_NUMBER}.fcl 
+  TEST_ARGS -s test${TEST_NUMBER}.fcl -c test${TEST_NUMBER}.fcl -t ${TEST_NAME})

--- a/test/DataFormats/Fhicl/fcl2dbjson/test003/test012.fcl
+++ b/test/DataFormats/Fhicl/fcl2dbjson/test003/test012.fcl
@@ -1,4 +1,4 @@
 #test pattern
-pattern: "(.*)common_code\/(.*[^\d])(\d*)(\.fcl$)" #test pattern1
+pattern: '(.*)common_code\/(.*[^\d])(\d*)(\.fcl$)' #test pattern1
 #test patterns
-patterns: ["(.*)((BoardReader_TOY\d+|BoardReader)_(.*[^_])_(\d+))(\.fcl$)", "(.*)((EventBuilder)_(.*[^_])_(\d+))(\.fcl$)", "(.*)((Aggregator)_(.*[^_])_(\d+))(\.fcl$)", "(.*)((metadata)(.*[^\d])(\d*))(\.fcl$)"] 
+patterns: ['(.*)((BoardReader_TOY\d+|BoardReader)_(.*[^_])_(\d+))(\.fcl$)', '(.*)((EventBuilder)_(.*[^_])_(\d+))(\.fcl$)', '(.*)((Aggregator)_(.*[^_])_(\d+))(\.fcl$)', '(.*)((metadata)(.*[^\d])(\d*))(\.fcl$)'] 

--- a/test/DataFormats/Fhicl/fcl2dbjson/test003/test015.fcl
+++ b/test/DataFormats/Fhicl/fcl2dbjson/test003/test015.fcl
@@ -1,0 +1,18 @@
+ 
+#include "EventBuilder_standard.fcl" 
+
+daq.metrics.graphite.namespace: "icarus.evb10." 
+
+daq.metrics.evbFile.fileName: "/daq/log/metrics/evb10_metrics.log" 
+
+outputs.normalOutput.fileName: "/data/daq/data_dl10_run%R_%#_%to.root" // #_%to.root' #_%to.root'
+
+outputs.testOutput.fileName: "/data/test_daq/data_dl10_run%R_%#_%to.root" #  #_%to.root " #_%to.root" '"sdfas #dfas"'
+#physics.my_output_modules: [ testOutput, rootNetOutput ]
+process_name: DAQEVB10 
+
+outputs.normalOutputBNBMAJORITY.fileName: '/data/daq/data_dl10_fstrmBNBMAJORITY_run%R_%#_%to.root' #_%to.root" #_%to.root'
+
+outputs.normalOutputNUMIMAJORITY.fileName: '/data/daq/data_dl10_fstrmNUMIMAJORITY_run%R_%#_%to.root' #"_%to.root' #_%to.root'"
+
+outputs.normalOutputOffBeamBNBMAJORITY.fileName: '/data/daq/data_dl10_fstrmOffBeamBNBMAJORITY_run%R_%#_%to.root' 

--- a/test/DataFormats/Fhicl/fcl2dbjson/test003/test016.fcl
+++ b/test/DataFormats/Fhicl/fcl2dbjson/test003/test016.fcl
@@ -1,0 +1,16 @@
+ 
+#include "EventBuilder_standard.fcl" 
+
+daq1.metrics.graphite.namespace: "icarus.evb10." 
+
+daq2.metrics.evbFile.fileName: "/daq/log/me'trics/evb1'0_'#met'rics.log" 
+
+daq3.metrics.evbFile.fileName: "/daq/log/metr'ics/evb10_#metrics.log" 
+
+daq4.metrics.evbFile.fileName: "/daq/log/metr'ic#s'/evb10_#metrics.log" 
+
+daq5.metrics.evbFile.fileName: '/daq/log/metr"ics/evb10_#metrics.log' // #_%to.root' #_%to.root'
+
+outputs6.normalOutput.fileName: "/data/daq/data_dl10_run%R_%#_%to.root" // #_%to.root' #_%to.root'
+
+outputs7.testOutput.fileName: "/data/test_daq/data_dl10_run%R_%#_%to.root" #  #_%to.root " #_%to.root" 'sdfas #dfas'


### PR DESCRIPTION
Testing instructions:
```
export my_work_dir=~/<my-work-area>

cd ${my_work_dir}
mkdir builddir
export RUN_TESTS=true
source ../artdaq_database/ups/setup_for_development -p
buildtool -t -j32

export my_test_bin=$(ls ${my_work_dir}/build/*/*/ConvertFhicl_t |head -1)

for t in ${my_work_dir}/artdaq_database/test/DataFormats/Fhicl/fcl2dbjson/test003/*.fcl; do \
${my_test_bin} -s ${t} -c ${t} -t RoundConvert_Fhicl2DBJson ; done
```